### PR TITLE
BUGFIX: Fix support for parameters with default values

### DIFF
--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -107,11 +107,13 @@ final class OpenApiGenerator
 
                 $parameterSchema = self::reflectionTypeToSchema($parameterReflectionType);
                 $parameterJsonSchema = $this->jsonSchemaGenerator->fromSchema($parameterSchema);
-                $defaultParameterValue = null;
                 if ($reflectionParameter->isDefaultValueAvailable()) {
                     $defaultParameterValue = $reflectionParameter->getDefaultValue();
                     if ($defaultParameterValue instanceof UnitEnum) {
                         $defaultParameterValue = $defaultParameterValue->name;
+                    }
+                    if (method_exists($parameterJsonSchema, 'with')) {
+                        $parameterJsonSchema = $parameterJsonSchema->with(default: $defaultParameterValue); // @phpstan-ignore-line
                     }
                 }
                 /** @var Parameter|null $parameterAttributeInstance */
@@ -126,7 +128,6 @@ final class OpenApiGenerator
                         description: self::getDescription($reflectionParameter),
                         required: !$reflectionParameter->isOptional(),
                         schema: $parameterJsonSchema,
-                        default: $defaultParameterValue,
                         meta: [
                             'schema' => $parameterSchema,
                             'parameterName' => $reflectionParameter->name,
@@ -141,7 +142,6 @@ final class OpenApiGenerator
                         description: self::getDescription($reflectionParameter),
                         required: !$reflectionParameter->isOptional(),
                         schema: $parameterJsonSchema,
-                        default: $defaultParameterValue,
                         meta: [
                             'schema' => $parameterSchema,
                             'parameterName' => $reflectionParameter->name,
@@ -171,7 +171,6 @@ final class OpenApiGenerator
                         description: self::getDescription($reflectionParameter),
                         required: !$reflectionParameter->isOptional(),
                         schema: $parameterJsonSchema,
-                        default: $defaultParameterValue,
                         meta: [
                             'schema' => $parameterSchema,
                             'parameterName' => $reflectionParameter->name,

--- a/src/Types/ParameterObject.php
+++ b/src/Types/ParameterObject.php
@@ -14,7 +14,6 @@ use Wwwision\JsonSchema as Json;
 final class ParameterObject implements JsonSerializable
 {
     /**
-     * @param mixed|null $default This parameter is not documented in the specification, but it seems to be supported and can be a good fit when referring to a component Schema with a different default value
      * @param array<string, mixed> $meta key/value for custom metadata. This is not part of the OpenAPI specification and won't appear in the JSON serialized format
      */
     public function __construct(
@@ -29,7 +28,6 @@ final class ParameterObject implements JsonSerializable
         public readonly null|Json\Schema $schema = null,
         // TODO add examples
         // TODO add content
-        public readonly mixed $default = null,
         public readonly array $meta = [],
     ) {
         if ($this->required === false && $this->in === ParameterLocation::path) {

--- a/tests/PHPUnit/Fixture/Fixture.php
+++ b/tests/PHPUnit/Fixture/Fixture.php
@@ -15,8 +15,10 @@ use Wwwision\Types\Attributes\StringBased;
 use Wwwision\Types\Schema\StringTypeFormat;
 use Wwwision\TypesOpenApi\Attributes\OpenApi;
 use Wwwision\TypesOpenApi\Attributes\Operation;
+use Wwwision\TypesOpenApi\Attributes\Parameter;
 use Wwwision\TypesOpenApi\Response\NotFoundResponse;
 use Wwwision\TypesOpenApi\Types\HttpMethod;
+use Wwwision\TypesOpenApi\Types\ParameterLocation;
 
 use function Wwwision\Types\instantiate;
 
@@ -171,6 +173,29 @@ final class ApiWithTheSamePathStructureButDifferentMethods
     {
         return 'mine';
     }
+}
+
+final class ApiWithParameters
+{
+    #[Operation(path: '/required-params', method: HttpMethod::GET)]
+    public function requiredParams(
+        #[Parameter(in: ParameterLocation::query, name: 'query-param')]
+        string $param1,
+        #[Parameter(in: ParameterLocation::header, name: 'X-Header-Param')]
+        int $param2,
+        #[Parameter(in: ParameterLocation::cookie, name: 'Cookie-Param')]
+        bool $param3,
+    ): void {}
+
+    #[Operation(path: '/optional-params', method: HttpMethod::GET)]
+    public function optionalParams(
+        #[Parameter(in: ParameterLocation::query, name: 'query-param')]
+        string $param1 = 'default',
+        #[Parameter(in: ParameterLocation::header, name: 'X-Header-Param')]
+        int $param2 = 123,
+        #[Parameter(in: ParameterLocation::cookie, name: 'Cookie-Param')]
+        bool $param3 = true,
+    ): void {}
 }
 
 #[Description('SomeInterface description')]

--- a/tests/PHPUnit/OpenApiGeneratorTest.php
+++ b/tests/PHPUnit/OpenApiGeneratorTest.php
@@ -241,6 +241,99 @@ final class OpenApiGeneratorTest extends TestCase
     }
 
 
+    public function test_generate_apiWithParameters(): void
+    {
+        $schema = (new OpenApiGenerator())->generate(Fixture\ApiWithParameters::class);
+        $expected = <<<'JSON'
+        {
+            "openapi": "3.0.3",
+            "info": {
+                "title": "",
+                "version": "0.0.0"
+            },
+            "paths": {
+                "\/required-params": {
+                    "get": {
+                        "operationId": "requiredParams",
+                        "parameters": [
+                            {
+                                "name": "query-param",
+                                "in": "query",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "name": "X-Header-Param",
+                                "in": "header",
+                                "required": true,
+                                "schema": {
+                                    "type": "integer"
+                                }
+                            },
+                            {
+                                "name": "Cookie-Param",
+                                "in": "cookie",
+                                "required": true,
+                                "schema": {
+                                    "type": "boolean"
+                                }
+                            }
+                        ],
+                        "responses": {
+                            "400": {
+                                "description": "Bad Request"
+                            }
+                        }
+                    }
+                },
+                "\/optional-params": {
+                    "get": {
+                        "operationId": "optionalParams",
+                        "parameters": [
+                            {
+                                "name": "query-param",
+                                "in": "query",
+                                "required": false,
+                                "schema": {
+                                    "type": "string",
+                                    "default": "default"
+                                }
+                            },
+                            {
+                                "name": "X-Header-Param",
+                                "in": "header",
+                                "required": false,
+                                "schema": {
+                                    "type": "integer",
+                                    "default": 123
+                                }
+                            },
+                            {
+                                "name": "Cookie-Param",
+                                "in": "cookie",
+                                "required": false,
+                                "schema": {
+                                    "type": "boolean",
+                                    "default": true
+                                }
+                            }
+                        ],
+                        "responses": {
+                            "400": {
+                                "description": "Bad Request"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        JSON;
+
+        self::assertJsonStringEqualsJsonString($expected, json_encode($schema, JSON_THROW_ON_ERROR));
+    }
+
     /**
      * @return iterable<mixed>
      */


### PR DESCRIPTION
Previously, the `default` value of optional query/header/cookie parameters was exposed as part of the `ParameterObject`. With this change it is part of the parameter *schema*

Fixes: #9